### PR TITLE
Add support for completely private baz schemas

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,24 +8,25 @@ configured_database_url = System.get_env("DATABASE_URL") || default_database_url
 database_url = "#{String.replace(configured_database_url, "?", env)}#{partition}"
 database_pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")
 schema_prefix = System.get_env("SCHEMA_PREFIX", nil)
-oban_schema_prefix = System.get_env("BAZ_OBAN_TABLE_PREFIX", "baz_private")
-
-#config :baz, table_and_index_prefix: "baz"
+oban_table_prefix = System.get_env("BAZ_OBAN_TABLE_PREFIX", nil)
 
 config :baz, Baz.Repo,
        url: database_url,
        pool_size: database_pool_size
 
 if schema_prefix != nil do
-  query_args = ["SET search_path TO #{schema_prefix}", []]
+  set_search_path_query_args = ["SET search_path TO #{schema_prefix}", []]
   config :baz, Baz.Repo,
     migration_default_prefix: "#{schema_prefix}",
-    after_connect: {Postgrex, :query!, query_args}
+    after_connect: {Postgrex, :query!, set_search_path_query_args}
 end
 
 # Oban Job Processing
+if oban_table_prefix != nil do
+  config :baz, Oban, prefix: oban_table_prefix
+end
+
 config :baz, Oban,
-  prefix: oban_schema_prefix,
   repo: Baz.Repo,
   plugins: [
     Oban.Plugins.Pruner

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -3,7 +3,7 @@ import Config
 # Database
 env = config_env() |> Atom.to_string()
 partition = System.get_env("MIX_TEST_PARTITION")
-default_database_url = "ecto://postgres:postgres@localhost:5431/baz_?"
+default_database_url = "ecto://postgres:postgres@localhost:5432/baz_?"
 configured_database_url = System.get_env("DATABASE_URL") || default_database_url
 database_url = "#{String.replace(configured_database_url, "?", env)}#{partition}"
 database_pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,17 +7,17 @@ default_database_url = "ecto://postgres:postgres@localhost:5432/baz_?"
 configured_database_url = System.get_env("DATABASE_URL") || default_database_url
 database_url = "#{String.replace(configured_database_url, "?", env)}#{partition}"
 database_pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")
-schema_prefix = System.get_env("SCHEMA_PREFIX", nil)
+baz_schema_prefix = System.get_env("BAZ_SCHEMA_PREFIX", nil)
 oban_table_prefix = System.get_env("BAZ_OBAN_TABLE_PREFIX", nil)
 
 config :baz, Baz.Repo,
        url: database_url,
        pool_size: database_pool_size
 
-if schema_prefix != nil do
-  set_search_path_query_args = ["SET search_path TO #{schema_prefix}", []]
+if baz_schema_prefix != nil do
+  set_search_path_query_args = ["SET search_path TO #{baz_schema_prefix}", []]
   config :baz, Baz.Repo,
-    migration_default_prefix: "#{schema_prefix}",
+    migration_default_prefix: "#{baz_schema_prefix}",
     after_connect: {Postgrex, :query!, set_search_path_query_args}
 end
 

--- a/lib/baz/migrations.ex
+++ b/lib/baz/migrations.ex
@@ -3,4 +3,15 @@ defmodule Baz.Migrations do
   def table_and_index_prefix do
     Application.get_env(:baz, :table_and_index_prefix, nil)
   end
+
+  @spec migration_prefix :: atom | nil
+  def migration_prefix do
+    Application.get_env(:baz, Baz.Repo)[:migration_default_prefix]
+  end
+
+  @spec oban_table_prefix :: atom | nil
+  def oban_table_prefix do
+    Application.get_env(:baz, Oban)[:prefix]
+  end
+
 end

--- a/lib/baz/migrations.ex
+++ b/lib/baz/migrations.ex
@@ -1,8 +1,4 @@
 defmodule Baz.Migrations do
-  @spec table_and_index_prefix :: atom | nil
-  def table_and_index_prefix do
-    Application.get_env(:baz, :table_and_index_prefix, nil)
-  end
 
   @spec migration_prefix :: atom | nil
   def migration_prefix do

--- a/lib/mix/tasks/baz.gen.migration.ex
+++ b/lib/mix/tasks/baz.gen.migration.ex
@@ -31,7 +31,6 @@ defmodule Mix.Tasks.Baz.Gen.Migration do
         |> Enum.map(fn source_path ->
           EEx.eval_file(source_path,
             module_prefix: app_module,
-            table_and_index_prefix: Baz.Migrations.table_and_index_prefix(),
             migration_prefix: Baz.Migrations.migration_prefix(),
             oban_table_prefix: Baz.Migrations.oban_table_prefix()
           )

--- a/lib/mix/tasks/baz.gen.migration.ex
+++ b/lib/mix/tasks/baz.gen.migration.ex
@@ -31,7 +31,9 @@ defmodule Mix.Tasks.Baz.Gen.Migration do
         |> Enum.map(fn source_path ->
           EEx.eval_file(source_path,
             module_prefix: app_module,
-            table_and_index_prefix: Baz.Migrations.table_and_index_prefix()
+            table_and_index_prefix: Baz.Migrations.table_and_index_prefix(),
+            migration_prefix: Baz.Migrations.migration_prefix(),
+            oban_table_prefix: Baz.Migrations.oban_table_prefix()
           )
         end)
 

--- a/priv/templates/migrations/20220411080750_create_collections.exs.eex
+++ b/priv/templates/migrations/20220411080750_create_collections.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollections do
   use Ecto.Migration
 
   def change do
-    create table(:collections<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collections) do
       add :venue, :text, null: false
       add :slug, :text, null: false
       add :name, :text, null: false
@@ -13,6 +13,6 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollections do
       timestamps()
     end
 
-    create index(:collections, [:slug], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collections, [:slug], unique: true)
   end
 end

--- a/priv/templates/migrations/20220411080840_create_collection_asset_contracts.exs.eex
+++ b/priv/templates/migrations/20220411080840_create_collection_asset_contracts.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssetContracts do
   use Ecto.Migration
 
   def change do
-    create table(:collection_asset_contracts<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_asset_contracts) do
       add :venue, :text, null: false
       add :slug, :text, null: false
       add :address, :string, null: false
@@ -19,6 +19,6 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssetContracts do
       timestamps()
     end
 
-    create index(:collection_asset_contracts, [:venue, :slug, :address], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_asset_contracts, [:venue, :slug, :address], unique: true)
   end
 end

--- a/priv/templates/migrations/20220411080918_create_collection_packs.exs.eex
+++ b/priv/templates/migrations/20220411080918_create_collection_packs.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionPacks do
   use Ecto.Migration
 
   def change do
-    create table(:collection_packs<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_packs) do
       add :slug, :text, null: false
       add :name, :text, null: false
       add :description, :text
@@ -14,6 +14,6 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionPacks do
       timestamps()
     end
 
-    create index(:collection_packs, [:slug], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_packs, [:slug], unique: true)
   end
 end

--- a/priv/templates/migrations/20220411081056_create_collection_pack_collections.exs.eex
+++ b/priv/templates/migrations/20220411081056_create_collection_pack_collections.exs.eex
@@ -2,13 +2,13 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionPackCollections d
   use Ecto.Migration
 
   def change do
-    create table(:collection_pack_collections<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_pack_collections) do
       add :collection_pack_id, references(:collection_packs), null: false
       add :collection_id, references(:collections), null: false
 
       timestamps()
     end
 
-    create index(:collection_pack_collections, [:collection_pack_id, :collection_id], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_pack_collections, [:collection_pack_id, :collection_id], unique: true)
   end
 end

--- a/priv/templates/migrations/20220411082211_create_collection_traits.exs.eex
+++ b/priv/templates/migrations/20220411082211_create_collection_traits.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionTraits do
   use Ecto.Migration
 
   def change do
-    create table(:collection_traits<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_traits) do
       add :collection_id, references(:collections), null: false
       add :trait_type, :text, null: false
       add :value, :text, null: false

--- a/priv/templates/migrations/20220411082654_create_collection_pack_traits.exs.eex
+++ b/priv/templates/migrations/20220411082654_create_collection_pack_traits.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionPackTraits do
   use Ecto.Migration
 
   def change do
-    create table(:collection_pack_traits<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_pack_traits) do
       add :collection_pack_id, references(:collection_packs), null: false
       add :trait_type, :text, null: false
       add :value, :text, null: false

--- a/priv/templates/migrations/20220412020948_create_collection_assets.exs.eex
+++ b/priv/templates/migrations/20220412020948_create_collection_assets.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssets do
   use Ecto.Migration
 
   def change do
-    create table(:collection_assets<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_assets) do
       add :venue, :text, null: false
       add :slug, :text, null: false
       add :token_id, :integer, null: false
@@ -20,6 +20,6 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssets do
       timestamps()
     end
 
-    create index(:collection_assets, [:venue, :slug, :token_id], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_assets, [:venue, :slug, :token_id], unique: true)
   end
 end

--- a/priv/templates/migrations/20220412021240_create_collection_pack_assets.exs.eex
+++ b/priv/templates/migrations/20220412021240_create_collection_pack_assets.exs.eex
@@ -2,13 +2,13 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionPackAssets do
   use Ecto.Migration
 
   def change do
-    create table(:collection_pack_assets<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_pack_assets) do
       add :collection_pack_id, references(:collection_packs), null: false
       add :token_id, :integer, null: false
 
       timestamps()
     end
 
-    create index(:collection_pack_assets, [:collection_pack_id, :token_id], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_pack_assets, [:collection_pack_id, :token_id], unique: true)
   end
 end

--- a/priv/templates/migrations/20220412080621_add_oban_jobs_table.exs.eex
+++ b/priv/templates/migrations/20220412080621_add_oban_jobs_table.exs.eex
@@ -2,12 +2,12 @@ defmodule <%= module_prefix %>.Repo.Migrations.AddObanJobsTable do
   use Ecto.Migration
 
   def up do
-    Oban.Migrations.up(version: 11)
+    Oban.Migrations.up(<%= if not is_nil(oban_table_prefix), do: "prefix: \"#{oban_table_prefix}\", " %>  version: 11)
   end
 
   # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if
   # necessary, regardless of which version we've migrated `up` to.
   def down do
-    Oban.Migrations.down(version: 1)
+    Oban.Migrations.down(<%= if not is_nil(oban_table_prefix), do: "prefix: \"#{oban_table_prefix}\", " %> version: 1)
   end
 end

--- a/priv/templates/migrations/20220412201543_create_collection_imports.exs.eex
+++ b/priv/templates/migrations/20220412201543_create_collection_imports.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionImports do
   use Ecto.Migration
 
   def change do
-    create table(:collection_imports<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_imports) do
       add :venue, :text, null: false
       add :slug, :text, null: false
       add :status, :string, null: false

--- a/priv/templates/migrations/20220412201548_create_collection_asset_imports.exs.eex
+++ b/priv/templates/migrations/20220412201548_create_collection_asset_imports.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssetImports do
   use Ecto.Migration
 
   def change do
-    create table(:collection_asset_imports<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_asset_imports) do
       add :venue, :text, null: false
       add :slug, :text, null: false
       add :token_ids, {:array, :integer}, null: true

--- a/priv/templates/migrations/20220412222312_create_collection_asset_import_pages.exs.eex
+++ b/priv/templates/migrations/20220412222312_create_collection_asset_import_pages.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssetImportPages 
   use Ecto.Migration
 
   def change do
-    create table(:collection_asset_import_pages<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_asset_import_pages) do
       add :collection_asset_import_id, references(:collection_asset_imports), null: false
       add :page_number, :integer, null: false
       add :next_page_cursor, :text, null: true
@@ -10,6 +10,6 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionAssetImportPages 
       timestamps()
     end
 
-    create index(:collection_asset_import_pages, [:collection_asset_import_id, :page_number], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_asset_import_pages, [:collection_asset_import_id, :page_number], unique: true)
   end
 end

--- a/priv/templates/migrations/20220415083299_create_collection_events.exs.eex
+++ b/priv/templates/migrations/20220415083299_create_collection_events.exs.eex
@@ -22,7 +22,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionEvents do
     """
     execute(create_query)
 
-    create table(:collection_events<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>, primary_key: false) do
+    create table(:collection_events, primary_key: false) do
       add :event_timestamp, :utc_datetime_usec, null: false
       add :event_type, :event_type, null: false
       add :venue, :text, null: false
@@ -38,7 +38,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionEvents do
   end
 
   def down do
-    drop table(:collection_events<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    drop table(:collection_events)
     execute("DROP TYPE event_type")
   end
 end

--- a/priv/templates/migrations/20220415083299_create_collection_events.exs.eex
+++ b/priv/templates/migrations/20220415083299_create_collection_events.exs.eex
@@ -32,7 +32,9 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionEvents do
       timestamps()
     end
 
-    execute "SELECT create_hypertable('collection_events<%= if not is_nil(table_and_index_prefix), do: "_#{table_and_index_prefix}" %>', 'event_timestamp');"
+    <%= if not is_nil(migration_prefix), do: "execute \"SET search_path to public;\""  %>
+    execute "SELECT create_hypertable('<%=if not is_nil(migration_prefix), do: "#{migration_prefix}."%>collection_events', 'event_timestamp');"
+    <%= if not is_nil(migration_prefix), do: "execute \"SET search_path to #{migration_prefix};\""  %>
   end
 
   def down do

--- a/priv/templates/migrations/20220415097051_create_collection_event_imports.exs.eex
+++ b/priv/templates/migrations/20220415097051_create_collection_event_imports.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionEventImports do
   use Ecto.Migration
 
   def change do
-    create table(:collection_event_imports<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_event_imports) do
       add :venue, :text, null: false
       add :slug, :text, null: false
       add :before, :utc_datetime_usec, null: false

--- a/priv/templates/migrations/20220415192307_create_collection_event_import_pages.exs.eex
+++ b/priv/templates/migrations/20220415192307_create_collection_event_import_pages.exs.eex
@@ -2,7 +2,7 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionEventImportPages 
   use Ecto.Migration
 
   def change do
-    create table(:collection_event_import_pages<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>) do
+    create table(:collection_event_import_pages) do
       add :collection_event_import_id, references(:collection_event_imports), null: false
       add :page_number, :integer, null: false
       add :next_page_cursor, :text, null: true
@@ -10,6 +10,6 @@ defmodule <%= module_prefix %>.Repo.Migrations.CreateCollectionEventImportPages 
       timestamps()
     end
 
-    create index(:collection_event_import_pages, [:collection_event_import_id, :page_number], unique: true<%= if not is_nil(table_and_index_prefix), do: ", prefix: \"#{table_and_index_prefix}\"" %>)
+    create index(:collection_event_import_pages, [:collection_event_import_id, :page_number], unique: true)
   end
 end


### PR DESCRIPTION
Added support for two separate schemas:  one for baz tables and one for baz oban tables.  Env configurable.  Baz schema is optional, configured by `BAZ_SCHEMA_PREFIX`,  oban table prefix is separate env var `BAZ_OBAN_TABLE_PREFIX` and also optional, but would be alwyas better to be sitting in some private schema to be able to configure access to it to "oban-admins" only (whomever wants to be that person ;) 

NOTE: `after_connect` setting ensures that ALL the baz queries run against this schema and no need to configure individual Ecto modules to set schema.    With it even `schema_migration` tables will be in private schema i.e. `baz.schema_migratiosn`  that way baz stuff is completely separate from whatever other DB is using it. 